### PR TITLE
Feature/bounding box

### DIFF
--- a/blueprint.pro
+++ b/blueprint.pro
@@ -20,7 +20,9 @@ SOURCES += src/main.cpp\
     src/model/Sketch.cpp \
     src/model/Blueprint.cpp \
     src/model/BezierElement.cpp \
-    src/model/SketchItemRectangle.cpp
+    src/model/SketchItemRectangle.cpp \
+    src/model/BoundingBox.cpp \
+    src/model/BoundingBoxPoint.cpp
 
 HEADERS  += src/MainWindow.h \
     src/CanvasView.h \
@@ -34,6 +36,8 @@ HEADERS  += src/MainWindow.h \
     src/model/Sketch.h \
     src/model/Blueprint.h \
     src/model/BezierElement.h \
-    src/model/SketchItemRectangle.h
+    src/model/SketchItemRectangle.h \
+    src/model/BoundingBox.h \
+    src/model/BoundingBoxPoint.h
 
 FORMS    += src/MainWindow.ui

--- a/src/model/BoundingBox.cpp
+++ b/src/model/BoundingBox.cpp
@@ -45,6 +45,31 @@ void BoundingBox::updateRect()
     x = boundingRect.x() + boundingRect.width() - halfSize;
     y = boundingRect.y() - halfSize;
     mTopRightHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position right handle
+    x = boundingRect.x() + boundingRect.width() - halfSize;
+    y = boundingRect.y() + (boundingRect.height() / 2) - halfSize;
+    mRightHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position bottom right handle
+    x = boundingRect.x() + boundingRect.width() - halfSize;
+    y = boundingRect.y() + boundingRect.height() - halfSize;
+    mBottomRight.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position bottom handle
+    x = boundingRect.x() + (boundingRect.width() / 2) - halfSize;
+    y = boundingRect.y() + boundingRect.height() - halfSize;
+    mBottom.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position bottom left handle
+    x = boundingRect.x() - halfSize;
+    y = boundingRect.y() + boundingRect.height() - halfSize;
+    mBottomLeft.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position left handle
+    x = boundingRect.x() - halfSize;
+    y = boundingRect.y() + (boundingRect.height() / 2) - halfSize;
+    mLeft.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
 }
 
 void BoundingBox::boundingBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta)

--- a/src/model/BoundingBox.cpp
+++ b/src/model/BoundingBox.cpp
@@ -1,0 +1,30 @@
+#include "BoundingBox.h"
+
+#include "SketchItem.h"
+
+BoundingBox::BoundingBox(SketchItem* parentSketchItem)
+    : QGraphicsRectItem(parentSketchItem->getGraphicsItem()),
+      mParentSketchItem(parentSketchItem)
+{
+    mTopHandle.setParentItem(this);
+}
+
+BoundingBox::~BoundingBox()
+{
+}
+
+void BoundingBox::updateRect()
+{
+    QRectF boundingRect = mParentSketchItem->getGraphicsItem()->boundingRect();
+    setRect(boundingRect);
+
+    qreal x;
+    qreal y;
+    qreal halfSize = HANDLE_SIZE / 2.0f;
+
+    // position top handle
+    x = boundingRect.x() + (boundingRect.width() / 2) - halfSize;
+    y = boundingRect.y() - halfSize;
+    mTopHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+}
+

--- a/src/model/BoundingBox.cpp
+++ b/src/model/BoundingBox.cpp
@@ -4,9 +4,16 @@
 
 BoundingBox::BoundingBox(SketchItem* parentSketchItem)
     : QGraphicsRectItem(parentSketchItem->getGraphicsItem()),
-      mParentSketchItem(parentSketchItem)
+      mParentSketchItem(parentSketchItem),
+    mTopLeftHandle(this, BoundingBoxPoint::TOP_LEFT),
+    mTopHandle(this, BoundingBoxPoint::TOP),
+    mTopRightHandle(this, BoundingBoxPoint::TOP_RIGHT),
+    mRightHandle(this, BoundingBoxPoint::RIGHT),
+    mBottomRight(this, BoundingBoxPoint::BOTTOM_RIGHT),
+    mBottom(this, BoundingBoxPoint::BOTTOM),
+    mBottomLeft(this, BoundingBoxPoint::BOTTOM_LEFT),
+    mLeft(this, BoundingBoxPoint::LEFT)
 {
-    mTopHandle.setParentItem(this);
 }
 
 BoundingBox::~BoundingBox()
@@ -16,15 +23,33 @@ BoundingBox::~BoundingBox()
 void BoundingBox::updateRect()
 {
     QRectF boundingRect = mParentSketchItem->getGraphicsItem()->boundingRect();
+    qreal marginAdjust = 10;
+    boundingRect.adjust(-marginAdjust, -marginAdjust, marginAdjust, marginAdjust);
     setRect(boundingRect);
 
     qreal x;
     qreal y;
     qreal halfSize = HANDLE_SIZE / 2.0f;
 
+    // position top left handle
+    x = boundingRect.x() - halfSize;
+    y = boundingRect.y() - halfSize;
+    mTopLeftHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
     // position top handle
     x = boundingRect.x() + (boundingRect.width() / 2) - halfSize;
     y = boundingRect.y() - halfSize;
     mTopHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
+
+    // position top right handle
+    x = boundingRect.x() + boundingRect.width() - halfSize;
+    y = boundingRect.y() - halfSize;
+    mTopRightHandle.setRect(x, y, HANDLE_SIZE, HANDLE_SIZE);
 }
+
+void BoundingBox::boundingBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta)
+{
+    mParentSketchItem->boundBoxPointMoved(direction, delta);
+}
+
 

--- a/src/model/BoundingBox.h
+++ b/src/model/BoundingBox.h
@@ -1,0 +1,30 @@
+#ifndef BOUNDINGBOX_H
+#define BOUNDINGBOX_H
+
+#include <QGraphicsRectItem>
+#include <QPointF>
+
+#include "BoundingBoxPoint.h"
+
+class SketchItem;
+
+class BoundingBox : public QGraphicsRectItem
+{
+public:
+    const int HANDLE_SIZE = 10;
+    BoundingBox(SketchItem* parentSketchItem);
+    ~BoundingBox();
+
+    void updateRect();
+
+signals:
+    void resized(QPointF top, QPointF right, QPointF bottom, QPointF left);
+
+private:
+    SketchItem* mParentSketchItem;
+
+    BoundingBoxPoint mTopHandle;
+
+};
+
+#endif // BOUNDINGBOX_H

--- a/src/model/BoundingBox.h
+++ b/src/model/BoundingBox.h
@@ -16,14 +16,19 @@ public:
     ~BoundingBox();
 
     void updateRect();
-
-signals:
-    void resized(QPointF top, QPointF right, QPointF bottom, QPointF left);
+    void boundingBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta);
 
 private:
     SketchItem* mParentSketchItem;
 
+    BoundingBoxPoint mTopLeftHandle;
     BoundingBoxPoint mTopHandle;
+    BoundingBoxPoint mTopRightHandle;
+    BoundingBoxPoint mRightHandle;
+    BoundingBoxPoint mBottomRight;
+    BoundingBoxPoint mBottom;
+    BoundingBoxPoint mBottomLeft;
+    BoundingBoxPoint mLeft;
 
 };
 

--- a/src/model/BoundingBoxPoint.cpp
+++ b/src/model/BoundingBoxPoint.cpp
@@ -2,17 +2,16 @@
 
 #include <QBrush>
 #include <QDebug>
-#include <QGraphicsSceneDragDropEvent>
 
-BoundingBoxPoint::BoundingBoxPoint(QGraphicsItem* parent)
-    : QGraphicsRectItem(parent)
+#include "model/BoundingBox.h"
+
+BoundingBoxPoint::BoundingBoxPoint(BoundingBox* parent, TranslationDirection direction)
+    : QGraphicsRectItem(parent),
+      mParentBoundingBox(parent),
+      mTranslationDirection(direction)
 {
     setFlag(QGraphicsItem::ItemIsMovable);
     setFlag(QGraphicsItem::ItemSendsGeometryChanges);
-    setFlag(QGraphicsItem::ItemIsSelectable);
-    setFlag(QGraphicsItem::ItemIsFocusable);
-    setAcceptHoverEvents(true);
-    setAcceptDrops(true);
     setBrush(QBrush(Qt::blue));
 }
 
@@ -21,9 +20,17 @@ BoundingBoxPoint::~BoundingBoxPoint()
 
 }
 
-void BoundingBoxPoint::dragMoveEvent(QGraphicsSceneDragDropEvent* event)
+BoundingBoxPoint::TranslationDirection BoundingBoxPoint::getTranslationDirection() const
 {
-    QGraphicsRectItem::dragMoveEvent(event);
-    qDebug() << "Moving bounding box point" << event->pos();
+    return mTranslationDirection;
+}
+
+QVariant BoundingBoxPoint::itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value)
+{
+    if (change == ItemPositionChange) {
+        QPointF delta = value.toPointF() - pos();
+        mParentBoundingBox->boundingBoxPointMoved(mTranslationDirection, delta);
+    }
+    return QGraphicsItem::itemChange(change, value);
 }
 

--- a/src/model/BoundingBoxPoint.cpp
+++ b/src/model/BoundingBoxPoint.cpp
@@ -1,0 +1,29 @@
+#include "BoundingBoxPoint.h"
+
+#include <QBrush>
+#include <QDebug>
+#include <QGraphicsSceneDragDropEvent>
+
+BoundingBoxPoint::BoundingBoxPoint(QGraphicsItem* parent)
+    : QGraphicsRectItem(parent)
+{
+    setFlag(QGraphicsItem::ItemIsMovable);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges);
+    setFlag(QGraphicsItem::ItemIsSelectable);
+    setFlag(QGraphicsItem::ItemIsFocusable);
+    setAcceptHoverEvents(true);
+    setAcceptDrops(true);
+    setBrush(QBrush(Qt::blue));
+}
+
+BoundingBoxPoint::~BoundingBoxPoint()
+{
+
+}
+
+void BoundingBoxPoint::dragMoveEvent(QGraphicsSceneDragDropEvent* event)
+{
+    QGraphicsRectItem::dragMoveEvent(event);
+    qDebug() << "Moving bounding box point" << event->pos();
+}
+

--- a/src/model/BoundingBoxPoint.h
+++ b/src/model/BoundingBoxPoint.h
@@ -1,0 +1,18 @@
+#ifndef BOUNDINGBOXPOINT_H
+#define BOUNDINGBOXPOINT_H
+
+#include <QGraphicsRectItem>
+
+class QGraphicsSceneDragDropEvent;
+
+class BoundingBoxPoint : public QGraphicsRectItem
+{
+public:
+    BoundingBoxPoint(QGraphicsItem* parent=0);
+    ~BoundingBoxPoint();
+
+protected:
+    virtual void dragMoveEvent(QGraphicsSceneDragDropEvent* event);
+};
+
+#endif // BOUNDINGBOXPOINT_H

--- a/src/model/BoundingBoxPoint.h
+++ b/src/model/BoundingBoxPoint.h
@@ -3,16 +3,34 @@
 
 #include <QGraphicsRectItem>
 
-class QGraphicsSceneDragDropEvent;
+class BoundingBox;
 
 class BoundingBoxPoint : public QGraphicsRectItem
 {
 public:
-    BoundingBoxPoint(QGraphicsItem* parent=0);
+
+    enum TranslationDirection {
+        TOP_LEFT,
+        TOP,
+        TOP_RIGHT,
+        RIGHT,
+        BOTTOM_RIGHT,
+        BOTTOM,
+        BOTTOM_LEFT,
+        LEFT,
+    };
+
+    BoundingBoxPoint(BoundingBox* parent, TranslationDirection direction);
     ~BoundingBoxPoint();
 
+    TranslationDirection getTranslationDirection() const;
+
 protected:
-    virtual void dragMoveEvent(QGraphicsSceneDragDropEvent* event);
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+
+private:
+    BoundingBox* mParentBoundingBox;
+    TranslationDirection mTranslationDirection;
 };
 
 #endif // BOUNDINGBOXPOINT_H

--- a/src/model/SketchItem.h
+++ b/src/model/SketchItem.h
@@ -3,12 +3,16 @@
 
 #include <QGraphicsItem>
 
+#include "model/BoundingBoxPoint.h"
+
 class SketchItem
 {
 public:
     SketchItem();
     virtual ~SketchItem();
     virtual QGraphicsItem* getGraphicsItem() = 0;
+
+    virtual void boundBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta) = 0;
 
     QString name;
 

--- a/src/model/SketchItemBezier.cpp
+++ b/src/model/SketchItemBezier.cpp
@@ -5,7 +5,6 @@
 #include <QPen>
 #include <QPointF>
 
-#include "BezierElement.h"
 #include "BezierControlPoint.h"
 #include "BezierPoint.h"
 

--- a/src/model/SketchItemBezier.cpp
+++ b/src/model/SketchItemBezier.cpp
@@ -14,6 +14,7 @@ SketchItemBezier::SketchItemBezier(qreal x, qreal y)
       mItem(new QGraphicsPathItem),
       mPath(),
       mElements(),
+      mBoundingBox(new BoundingBox(this)),
       mIsPathClosed(false)
 {
     mItem->setPen(QPen(QColor(79, 106, 25), 1, Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin));

--- a/src/model/SketchItemBezier.h
+++ b/src/model/SketchItemBezier.h
@@ -7,11 +7,11 @@
 #include <QGraphicsPathItem>
 #include <QGraphicsEllipseItem>
 
+#include "BezierElement.h"
 #include "BoundingBox.h"
 
 class QPointF;
 class BezierPath;
-class BezierElement;
 
 class SketchItemBezier : public SketchItem
 {

--- a/src/model/SketchItemBezier.h
+++ b/src/model/SketchItemBezier.h
@@ -7,6 +7,8 @@
 #include <QGraphicsPathItem>
 #include <QGraphicsEllipseItem>
 
+#include "BoundingBox.h"
+
 class QPointF;
 class BezierPath;
 class BezierElement;
@@ -21,10 +23,12 @@ public:
     void closePath();
     void updateElement(BezierElement* bezierElement, const QPointF& pos);
 
-    QPainterPath mPath;
-private:
+protected:
     QGraphicsPathItem* mItem;
+    QPainterPath mPath;
     QList<BezierElement*> mElements;
+    BoundingBox* mBoundingBox;
+
     bool mIsPathClosed;
 };
 

--- a/src/model/SketchItemEllipse.cpp
+++ b/src/model/SketchItemEllipse.cpp
@@ -12,3 +12,13 @@ SketchItemEllipse::SketchItemEllipse(qreal x, qreal y)
     closePath();
 }
 
+SketchItemEllipse::~SketchItemEllipse()
+{
+
+}
+
+void SketchItemEllipse::boundBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta)
+{
+
+}
+

--- a/src/model/SketchItemEllipse.h
+++ b/src/model/SketchItemEllipse.h
@@ -8,8 +8,9 @@ class SketchItemEllipse : public SketchItemBezier
 {
 public:
     SketchItemEllipse(qreal x, qreal y);
-    //~SketchItemEllipse();
+    ~SketchItemEllipse();
 
+    virtual void boundBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta);
 };
 
 #endif // SKETCHITEMCIRCLE_H

--- a/src/model/SketchItemRectangle.cpp
+++ b/src/model/SketchItemRectangle.cpp
@@ -1,5 +1,7 @@
 #include "SketchItemRectangle.h"
 
+#include <QDebug>
+
 SketchItemRectangle::SketchItemRectangle(qreal x, qreal y)
     : SketchItemBezier(x, y)
 {
@@ -8,6 +10,37 @@ SketchItemRectangle::SketchItemRectangle(qreal x, qreal y)
     addPath(QPointF(60, 50), QPointF(40, 50), QPointF(0, 50));
     addPath(QPointF(0, 40), QPointF(0, 20), QPointF(0, 0));
     closePath();
+    mBoundingBox->updateRect();
+}
+
+void SketchItemRectangle::boundBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta)
+{
+    QList<BezierElement*> elementsToMove;
+    // because the path is closed, we don't have to
+    // move the first item, the last is enough
+    switch (direction) {
+    case BoundingBoxPoint::TOP_LEFT:
+        elementsToMove.append(mElements.last()); // top left
+        mElements[3]->moveBy(QPointF(0, delta.y())); // top right
+        mElements[9]->moveBy(QPointF(delta.x(), 0)); // bottom left
+        break;
+    case BoundingBoxPoint::TOP:
+        elementsToMove.append(mElements[3]); // top right
+        elementsToMove.append(mElements.last()); // top left
+        break;
+
+    case BoundingBoxPoint::TOP_RIGHT:
+        elementsToMove.append(mElements[3]); // top right
+        mElements.last()->moveBy(QPointF(0, delta.y())); // top left
+        mElements[6]->moveBy(QPointF(delta.x(), 0)); // bottom right
+        break;
+    default:
+        break;
+    }
+
+    for (auto e : elementsToMove) {
+        e->moveBy(delta);
+    }
     mBoundingBox->updateRect();
 }
 

--- a/src/model/SketchItemRectangle.cpp
+++ b/src/model/SketchItemRectangle.cpp
@@ -8,5 +8,6 @@ SketchItemRectangle::SketchItemRectangle(qreal x, qreal y)
     addPath(QPointF(60, 50), QPointF(40, 50), QPointF(0, 50));
     addPath(QPointF(0, 40), QPointF(0, 20), QPointF(0, 0));
     closePath();
+    mBoundingBox->updateRect();
 }
 

--- a/src/model/SketchItemRectangle.h
+++ b/src/model/SketchItemRectangle.h
@@ -8,6 +8,8 @@ class SketchItemRectangle : public SketchItemBezier
 {
 public:
     SketchItemRectangle(qreal x, qreal y);
+
+    virtual void boundBoxPointMoved(BoundingBoxPoint::TranslationDirection direction, QPointF delta);
 };
 
 #endif // SKETCHITEMRECTANGLE_H


### PR DESCRIPTION
All bounding box handles are drawn, top-left/top/top-right are doing the job.

The missing bit is to:
- restrain the current handle to move twice, because the bounding box is moving, it moves it handles with it, which moves the current handle. Some kind of solution might be found here (http://stackoverflow.com/questions/24159632/qgraphicsitem-interactive-resizing), I don't know yet

I find the current way of moving the points quiet ugly, trying to think a bit ahead, by only adding a point in our path, it all falls appart. If you have a better idea, I'll be glad to discuss it!
