### PR TITLE
Display a grey mask on the shape part out of bounds

### DIFF
--- a/src/model/Canvas.cpp
+++ b/src/model/Canvas.cpp
@@ -9,7 +9,7 @@ Canvas::Canvas(TreeItem* parentItem, qreal x, qreal y)
 {
 
     mItemType = TreeItem::ItemType::CANVAS;
-    //mItem->setFlag(QGraphicsItem::ItemClipsChildrenToShape);
+    //setFlag(QGraphicsItem::ItemClipsChildrenToShape);
     setBorderColor(QColor(10, 10, 10));
     setBackgroundColor(QColor(255, 255, 255));
     boundingBox().boundingBoxPointMoved(BoundingBoxPoint::BOTTOM_RIGHT, QPointF(300.0, 500.0));

--- a/src/model/Shape.h
+++ b/src/model/Shape.h
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QGraphicsPathItem>
 #include <QGraphicsEllipseItem>
+#include <QPainter>
 
 #include "TreeItem.h"
 #include "BezierElement.h"
@@ -33,6 +34,7 @@ public:
 
     Shape(TreeItem* parentTreeItem, qreal x, qreal y);
     virtual ~Shape();
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
     void addPath(const QPointF& c1, const QPointF& c2, const QPointF& endPos);
     void closePath();
     void updateElement(BezierElement* bezierElement, const QPointF& pos);
@@ -46,7 +48,6 @@ public:
     void setBackgroundColor(const QColor& color);
     void setBorderColor(const QColor& color);
     inline BoundingBox& boundingBox() { return mBoundingBox; }
-
     QPointF posAbsolute();
 
 protected:


### PR DESCRIPTION
Not really perfect but it's display on the shape a grey mask for the out of canvas bounds part.

:ok: Only shape with a Canvas as parent are displayed correctly. :ok: 
:warning: Shape with another Shape for parent will have an unpredictable behavior :warning: 

Close #59
