### PR TITLE
Simplify ShapeLine algorithm

### DIFF
--- a/src/model/ShapeBezier.cpp
+++ b/src/model/ShapeBezier.cpp
@@ -1,7 +1,6 @@
 #include "ShapeBezier.h"
 
 #include <QDebug>
-#include <QtMath>
 #include <QBrush>
 #include <QPen>
 #include <QPainter>
@@ -185,6 +184,15 @@ void ShapeBezier::addPath(const QPointF& c1, const QPointF& c2, const QPointF& e
     mGraphicsItem->setPath(mPath);
 }
 
+void ShapeBezier::addSegment(const QPointF& point)
+{
+    QPointF lastPointPos(0 ,0);
+    if (!mElements.empty()) {
+        lastPointPos = mElements.last()->pos();
+    }
+    addPath(lastPointPos, point, point);
+}
+
 void ShapeBezier::closePath()
 {
     qDebug() << "Closing path";
@@ -210,29 +218,6 @@ void ShapeBezier::updateElement(BezierElement* bezierElement, const QPointF& pos
     if (listIndex >= 0
             && bezierElement->elementType() == BezierElement::POINT
             && mEditMode == EditMode::BEZIER) {
-
-        if (mShapeType == ShapeType::LINE) {
-
-            // Get Slope
-            QPointF refPos = mElements.first()->pos();
-            QPointF firstElementPos = mElements.first()->pos();
-            QPointF lastElementPos = mElements.last()->pos();
-            firstElementPos -= refPos;
-            lastElementPos -= refPos;
-
-            float distance = qSqrt(qPow(lastElementPos.x(), 2) + qPow(lastElementPos.y(), 2));
-            QPointF slope = lastElementPos / distance;
-
-            // Update new control first point position
-            float firstControlPointDistance = distance * 0.1f;
-            mElements[1]->setPos((slope * firstControlPointDistance) + refPos);
-
-            // Update new control last point position
-            float lastControlPointDistance = distance * 0.9f;
-            mElements[mElements.length() - 2]->setPos((slope * lastControlPointDistance) + refPos);
-
-        } else {
-
             if (bezierElement == mElements.first()) {
                 mElements[listIndex + 1]->moveBy(delta);
 
@@ -243,9 +228,7 @@ void ShapeBezier::updateElement(BezierElement* bezierElement, const QPointF& pos
                 mElements[listIndex - 1]->moveBy(delta);
                 mElements[listIndex + 1]->moveBy(delta);
             }
-        }
     }
-
 
     // Update path
     mGraphicsItem->setPath(mPath);

--- a/src/model/ShapeBezier.h
+++ b/src/model/ShapeBezier.h
@@ -28,6 +28,7 @@ public:
     void setBorderColor(const QColor& color);
 
     void addPath(const QPointF& c1, const QPointF& c2, const QPointF& endPos);
+    void addSegment(const QPointF& point);
     void closePath();
     void updateElement(BezierElement* bezierElement, const QPointF& pos);
     inline BoundingBox& boundingBox() { return mBoundingBox; }

--- a/src/model/ShapeLine.cpp
+++ b/src/model/ShapeLine.cpp
@@ -5,8 +5,7 @@ using namespace blueprint;
 ShapeLine::ShapeLine(Shape* parentShape, const qreal& x, const qreal& y)
     : ShapeBezier(parentShape, ShapeType::LINE, x, y)
 {
-    addPath(QPointF(10, 0), QPointF(20, 0), QPointF(30, 0));
-
+    addSegment(QPointF(10, 10));
     setBackgroundColor(QColor(0, 0, 0, 0));
     mEditMode = Shape::EditMode::BEZIER;
 }
@@ -18,14 +17,12 @@ ShapeLine::~ShapeLine()
 
 void ShapeLine::setEditMode(const Shape::EditMode& /*mode*/)
 {
-    // No op
+    // no-op
 }
 
 void ShapeLine::collapse()
 {
-    for (auto e : mElements) {
-        e->setPos(QPointF(0, 0));
-    }
+    // no-op
 }
 
 void ShapeLine::resizeOnCreation(const QPointF& delta)
@@ -41,6 +38,7 @@ void ShapeLine::updateBoundingBoxBezierVisibility()
         e->setVisible(bezierVisibility);
     }
 
+    // hide control points
     mElements[1]->setVisible(false);
     mElements[mElements.length() - 2]->setVisible(false);
 }


### PR DESCRIPTION
By putting control points and points at same coordinates,
there's no need to calculate any line formula. There are
other advantages:
- No wobbly effect when moving the line points
- Alright prepares the work for the bezier tool (by default
  it will be composed of straight segments).
