### PR TITLE
Delete selected shape on delete key press

### DIFF
--- a/src/CanvasView.h
+++ b/src/CanvasView.h
@@ -28,8 +28,8 @@ public:
 public slots:
     void setTool(blueprint::Tool::Type toolType);
     void onFocusItemChanged(QGraphicsItem* newFocusItem, QGraphicsItem* oldFocusItem, Qt::FocusReason reason);
-    void selectionsChanged(const QModelIndex& parent, int first, int last);
-    void propertiesChanged(const QModelIndex& parent, int first, int last);
+    void shapeSelected(blueprint::Shape* shape);
+    void shapePropertiesChanged(blueprint::Shape* shape);
 
 protected:
     // from QGraphicsView

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -27,6 +27,7 @@ public:
 
 private:
     void initToolbar();
+    void initSignalSlots();
 
 private slots:
     void setTool(blueprint::Tool::Type toolType);

--- a/src/PropertiesWindow.cpp
+++ b/src/PropertiesWindow.cpp
@@ -23,8 +23,8 @@ PropertiesWindow::PropertiesWindow(QWidget *parent) :
     connect(mUi->backgroundColor, &QPushButton::clicked, this, &PropertiesWindow::onBackgroundColorClicked);
     connect(mUi->backgroundImage, &QPushButton::clicked, this, &PropertiesWindow::onBackgroundImageClicked);
 
-    connect(ShapeModel::instance(), &ShapeModel::selectionsChanged, this, &PropertiesWindow::selectionsChanged);
-    connect(ShapeModel::instance(), &ShapeModel::propertiesChanged, this, &PropertiesWindow::selectionsChanged);
+    connect(ShapeModel::instance(), &ShapeModel::shapeSelected, this, &PropertiesWindow::shapeSelected);
+    connect(ShapeModel::instance(), &ShapeModel::shapePropertiesChanged, this, &PropertiesWindow::shapeSelected);
 }
 
 PropertiesWindow::~PropertiesWindow()
@@ -32,10 +32,9 @@ PropertiesWindow::~PropertiesWindow()
     delete mUi;
 }
 
-void PropertiesWindow::selectionsChanged(const QModelIndex& parent, int first, int /*last*/)
+void PropertiesWindow::shapeSelected(blueprint::Shape* shape)
 {
-    ShapeModel* model = ShapeModel::instance();
-    mCurrentItem = static_cast<blueprint::Shape*>(model->itemFromParentIndex(parent, first));
+    mCurrentItem = shape;
     Q_ASSERT(mCurrentItem);
 
     // Name
@@ -63,10 +62,7 @@ void PropertiesWindow::onBackgroundColorClicked()
 {
     QColor color = QColorDialog::getColor(mCurrentItem->backgroundColor(), this, "Background color", QColorDialog::ShowAlphaChannel);
     mCurrentItem->setBackgroundColor(color);
-
-    QModelIndex index = (QModelIndex)(*mCurrentItem->parentShape()->modelIndex());
-    int shapeIndex = mCurrentItem->parentShape()->indexOf(mCurrentItem);
-    ShapeModel::instance()->propertiesChanged(index, shapeIndex, shapeIndex);
+    ShapeModel::instance()->shapePropertiesChanged(mCurrentItem);
 }
 
 void PropertiesWindow::onBackgroundImageClicked()
@@ -80,7 +76,5 @@ void PropertiesWindow::onBackgroundImageClicked()
                                             "Image Files (*.png *.jpg *.bmp)");
 
     shapeBezier->setBackgroundImage(fileName);
-    QModelIndex index = (QModelIndex)(*mCurrentItem->parentShape()->modelIndex());
-    int shapeIndex = mCurrentItem->parentShape()->indexOf(mCurrentItem);
-    ShapeModel::instance()->propertiesChanged(index, shapeIndex, shapeIndex);
+    ShapeModel::instance()->shapePropertiesChanged(mCurrentItem);
 }

--- a/src/PropertiesWindow.h
+++ b/src/PropertiesWindow.h
@@ -18,7 +18,7 @@ public:
     ~PropertiesWindow();
 
 public slots:
-    void selectionsChanged(const QModelIndex& parent, int first, int last);
+    void shapeSelected(blueprint::Shape* shape);
     void onBackgroundColorClicked();
     void onBackgroundImageClicked();
 

--- a/src/model/Shape.cpp
+++ b/src/model/Shape.cpp
@@ -38,6 +38,11 @@ void Shape::appendChild(Shape* child)
     mChildItems.append(child);
 }
 
+bool Shape::removeChild(Shape* child)
+{
+    return mChildItems.removeOne(child);
+}
+
 Shape*Shape::child(int row)
 {
     return mChildItems.at(row);

--- a/src/model/Shape.h
+++ b/src/model/Shape.h
@@ -35,6 +35,7 @@ public:
     // hierarchy stuff
     Shape* child(int row);
     void appendChild(Shape* child);
+    bool removeChild(Shape* child);
     int indexOf(const Shape* child) const;
     int childCount() const;
     int columnCount() const;

--- a/src/model/ShapeModel.h
+++ b/src/model/ShapeModel.h
@@ -17,6 +17,8 @@ public:
     ~ShapeModel();
 
     void addItem(Shape* item, Shape* parent = 0);
+    void removeItem(Shape* item);
+
     Shape* itemFromIndex(const QModelIndex& index) const;
     Shape* itemFromParentIndex(const QModelIndex& parentIndex, int row) const;
 
@@ -34,8 +36,10 @@ public:
     void setRootItem(Shape* rootItem);
 
 signals:
-    void selectionsChanged(const QModelIndex& parent, int first, int last);
-    void propertiesChanged(const QModelIndex& parent, int first, int last);
+    void shapeAdded(Shape* shape);
+    void shapeRemoved(Shape* shape);
+    void shapeSelected(Shape* shape);
+    void shapePropertiesChanged(Shape* shape);
 
 private:
     Shape* mRootItem;


### PR DESCRIPTION
Right now it works only when the QGraphicsItem has the focus (meaning
not the TreeView).

We should subclass TreeView to override keyReleaseEvent, I did not do it
because today the "selected shape" data is only stored in CanvasView.
TreeView also needs this information to delete the proper Shape, I don't
know if we should centralize this somewhere (ShapeModel?), but it seems
quite ugly to completely duplicate the selection logic in TreeView.

Close #88
